### PR TITLE
 Feat : focus 이동의 대상을 생성된 input으로 한정

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -173,7 +173,7 @@ class TestModal extends Modal {
 
 		// 생성된 input태그들 지정
 		const inputs = Array.from(
-			this.contentEl.querySelectorAll("input")
+			this.contentEl.querySelectorAll("input.test-input")
 		) as HTMLInputElement[];
 
 		// 기능 구현을 위한 이벤트 리스너 추가


### PR DESCRIPTION
# 요약
focus 이동의 대상을 생성된 input으로 한정시킨다.
# 상세 내용
- 기존의 focus 이동은 다음과 같은 input들까지 이동 대상에 포함시켰다.
  -  마크다운 체크박스
  - 기존 content에 존재하는 \<input>태그
- querySelector에 조건을 추가하여 focus 대상을 Easy Test 플러그인에서 생성한 input으로 한정시켰다.
# 이슈
closes #10 